### PR TITLE
feat: xmobarをアップデート

### DIFF
--- a/.xmobarrc-bullet
+++ b/.xmobarrc-bullet
@@ -1,8 +1,9 @@
 Config
-{ font = "xft:monospace:antialias=true"
+{ font = "monospace"
+, dpi = 144
 , bgColor = "#002b36"
 , fgColor = "#93a1a1"
-, position = TopW L 90
+, position = TopSize L 90 32
 , lowerOnStart = False
 , commands =
   [ Run StdinReader

--- a/.xmobarrc-indigo
+++ b/.xmobarrc-indigo
@@ -1,8 +1,9 @@
 Config
-{ font = "xft:monospace:antialias=true"
+{ font = "monospace"
+, dpi = 144
 , bgColor = "#002b36"
 , fgColor = "#93a1a1"
-, position = TopW L 90
+, position = TopSize L 90 32
 , lowerOnStart = False
 , commands =
   [ Run StdinReader

--- a/install
+++ b/install
@@ -4,7 +4,7 @@ set -eux
 systemd_dir=${0:a:h}/systemd/
 hostname=$(hostname)
 
-stack install . xmobar-0.44 --flag xmobar:with_xft --flag xmobar:with_datezone
+LANG=C.utf8 stack install . xmobar --flag xmobar:with_datezone
 
 cd ../
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,3 @@
-resolver: lts-20.26
+resolver: lts-21.9
+extra-deps:
+  - xmobar-0.47.1

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,10 +3,17 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: xmobar-0.47.1@sha256:d380bc2b903cd6ffa859cb69a3876e4128013c179832315c8b7c698530680448,14934
+    pantry-tree:
+      sha256: 5e1c4eaf5f0570351d76707c617b4fcb244b83109f13e5138539600c808b8316
+      size: 9769
+  original:
+    hackage: xmobar-0.47.1
 snapshots:
 - completed:
-    sha256: 5a59b2a405b3aba3c00188453be172b85893cab8ebc352b1ef58b0eae5d248a2
-    size: 650475
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/20/26.yaml
-  original: lts-20.26
+    sha256: 2fc12a405ab6f7eac73eb11a0ca5ccca0e956bd2848db780c140b7406ff9ebb5
+    size: 640035
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/21/9.yaml
+  original: lts-21.9


### PR DESCRIPTION
* xftを使わなくなったのでフォント総称名のみを指定
* xftを使わなくなったのでxftのDPIを尊重しなくなったため直接指定
* dpiを考慮した幅サイズになっていなかったのでtrayerと同じ32幅に設定
* gtkに依存するようになっていたのでバグ回避のために`LANG`を設定してビルドする