### PR TITLE
feat!: Slackのアクティベートキーを`M--`から`M-s`に変更

### DIFF
--- a/src/XMonad/Key.hs
+++ b/src/XMonad/Key.hs
@@ -54,7 +54,7 @@ myKeys hostChassis conf@XConfig{modMask} = mkKeymap conf
   , ("M-h",   runOrRaiseNext "firefox"                 (className =? "firefox"))
   , ("M-t",   runOrRaiseNext "kitty"                   (className =? "kitty"))
   , ("M-n",   runOrRaiseNext "emacs"                   (className =? "Emacs"))
-  , ("M--",   runOrRaiseNext "slack"                   (className =? "Slack"))
+  , ("M-s",   runOrRaiseNext "slack"                   (className =? "Slack"))
 
   , ("M-f",   runOrRaiseNext "nautilus"                (className =? "org.gnome.Nautilus"))
   , ("M-g",   runOrRaiseNext "gimp"                    (className =? "Gimp"))


### PR DESCRIPTION
前はここはmikutterの席でした。
Twitter(X)のAPIの原則非公開化に伴いmikutterを使うのは著しく困難になりました。
TweetDeck(X Pro)の単体アプリ化をして使うか悩みましたが、
別にそんなに使うことも無いしむしろ仕事の邪魔になるなと思ってまだやっていません。
よりよく使うSlackのアクティベートキーをホームポジションの`M-s`に変更しました。
SでSlackの名前とも繋がってわかりやすい。
X Proを単体アプリ化して使うとしても`M--`の方にすると思います。