### PR TITLE
perf: xmobarのスレッド数を2にする

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -99,4 +99,4 @@ executables:
       - -O2
       - -threaded
       - -rtsopts
-      - -with-rtsopts=-N
+      - -with-rtsopts=-N2


### PR DESCRIPTION
ステータスバーに最高速を求めているわけではないのでコアを全部使って全速力で動かす必要はない。
ウィンドウマネージャの方は最高速で動かしたいが。
厳密に測っているわけではないがGCの分割オーバーヘッドなどの方が高くつきそう。
主にラップトップのバッテリーに優しくない。
かと言って流石にスレッド無効化は色々挙動が変わりそうなのでしたくはない。
よってワーカースレッドの数は2にしておく。
2なのはMeteor LakeのSoCタイルにあるような超少電力のコアでも2コアはあるのでそれぐらいは良いだろうという判断。 まあ今はIntelプロセッサ使っていないけど汎用性のある挙動ということで。