### PR TITLE
feat: xmobarの設定を最新のドキュメントに合わせる

### DIFF
--- a/src/XMonad/AppMain.hs
+++ b/src/XMonad/AppMain.hs
@@ -2,13 +2,13 @@ module XMonad.AppMain (appMain) where
 
 import           XMonad
 import           XMonad.Config
-import           XMonad.Hooks.DynamicLog
+import           XMonad.Hooks.StatusBar
 import           XMonad.Pp
 
 appMain :: IO ()
 appMain = do
   myConfig <- mkMyConfig
   let toggleStrutsKey XConfig{modMask} = (modMask, xK_u)
-  bar <- statusBar "xmobar-launch" myPP toggleStrutsKey myConfig
+      bar = withEasySB (statusBarProp "xmobar-launch" (pure myPP)) toggleStrutsKey myConfig
   directories <- getDirectories
   launch bar directories

--- a/src/Xmobar/Config.hs
+++ b/src/Xmobar/Config.hs
@@ -28,7 +28,7 @@ mkConfigByDevice = do
   temp <- getTemp
   battery <- getBattery
   let runnable =
-        [ Run StdinReader
+        [ Run XMonadLog
         , Run $ Cpu ["--ppad", "3"] basicRate
         , Run $ CpuFreq ["-t", "Freq: <max>GHz", "--ddigits", "2"] basicRate
         , Run $ Memory ["-t", "Mem: <used>M"] basicRate
@@ -44,7 +44,7 @@ mkConfigByDevice = do
       batteryTemplate = maybe "" ((", " <>) . snd) battery
   return
     ( runnable
-    , "}%StdinReader%{%cpu%, %cpufreq%, %memory%, %swap%, %diskio%, %dynnetwork%" <>
+    , "}%XMonadLog%{%cpu%, %cpufreq%, %memory%, %swap%, %diskio%, %dynnetwork%" <>
       tempTemplate <>
       batteryTemplate <>
       ", %date%"


### PR DESCRIPTION
最近のドキュメントを見直してみたら`StdinReader`ではなく`XMonadLog`が使われていたので特にこだわりが無いので変更する。