### PR TITLE
fix: 依存パッケージimagemagickおよびoxipngをflake.nixから削除

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,9 +58,7 @@
           paths = with pkgs; [
             birdtray
             copyq
-            imagemagick
             networkmanagerapplet
-            oxipng
             trayer
             xkbset
             xmobar-launch


### PR DESCRIPTION
ホストとコンフリクトする。
WSLでも使いたい。
