### PR TITLE
fix(keybindings): remove Skype keybinding from custom keymap

### DIFF
--- a/src/XMonad/Key.hs
+++ b/src/XMonad/Key.hs
@@ -44,7 +44,6 @@ myKeys hostChassis conf@XConfig{modMask} = mkKeymap conf
   , ("M-S-i", runOrRaiseNext "idea-community"          (className ~? "jetbrains-idea"))
 
   , ("M-p",   runOrRaiseNext "pavucontrol"             (className ~? "Pavucontrol"))
-  , ("M-S-p", runOrRaiseNext "skypeforlinux"           (className =? "Skype"))
   , ("M-y",   runOrRaiseNext "rhythmbox"               (className =? "Rhythmbox"))
 
   , ("M-x",   runOrRaiseNext "steam"                   (className =? "Steam"))


### PR DESCRIPTION
Skypeはもうかなり前から使っていなかったが、
明白にMicrosoftがサービス終了したのでクライアントを起動する意味はなくなった。
