### PR TITLE
fix: remove xkbset and related bouncekeys script

### DIFF
--- a/bin/xkbset-bouncekeys
+++ b/bin/xkbset-bouncekeys
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-if xkbset q|rg 'Bounce-Keys = Off'; then
-    xkbset bouncekeys 50
-else
-    echo "Bounce-Keys On"
-fi

--- a/flake.nix
+++ b/flake.nix
@@ -63,7 +63,6 @@
             copyq
             networkmanagerapplet
             trayer
-            xkbset
             xmobar-launch
             xmonad-helper-bin
             xmonad-launch


### PR DESCRIPTION
だいぶ前のラップトップPC向けのワークアラウンド。
不要になったので消します。
