### PR TITLE
feat: ステータスバーをOLED最適化

### DIFF
--- a/src/XMonad/Startup.hs
+++ b/src/XMonad/Startup.hs
@@ -26,6 +26,8 @@ myStartupHook = do
     , "--heighttype pixel"
     , "--height " <> show barHeight
     , "--monitor primary"
+    , "--transparent true"
+    , "--alpha 255"
     ]
   spawn "copyq"
   spawn "nm-applet"

--- a/src/Xmobar/Config.hs
+++ b/src/Xmobar/Config.hs
@@ -17,8 +17,8 @@ mkConfig = do
     defaultConfig
     { font = "monospace"
     , dpi
-    , bgColor = "#002b36"
-    , fgColor = "#93a1a1"
+    , bgColor = "#000000"
+    , fgColor = "#E0E0E0"
     , position = TopSize L 90 barHeight
     , lowerOnStart = False
     , commands = runnable


### PR DESCRIPTION
xmobarの背景を完全な黒にして、
文字色は完全ではない白に設定。
trayerの背景は透明にする。
