### PR TITLE
feat(key): add shortcut for claude-desktop and move chromium to M-S-c

### DIFF
--- a/src/XMonad/Key.hs
+++ b/src/XMonad/Key.hs
@@ -57,7 +57,8 @@ myKeys hostChassis conf@XConfig{modMask} = mkKeymap conf
 
   , ("M-f",   runOrRaiseNext "nautilus"                (className =? "org.gnome.Nautilus"))
   , ("M-g",   runOrRaiseNext "gimp"                    (className ~? "Gimp"))
-  , ("M-c",   runOrRaiseNext "chromium"                (className =? "Chromium-browser-chromium"))
+  , ("M-c",   runOrRaiseNext "claude-desktop"          (className =? "Claude"))
+  , ("M-S-c", runOrRaiseNext "chromium"                (className =? "Chromium-browser-chromium"))
   , ("M-r",   runOrRaiseNext "evince"                  (className =? "Evince"))
 
   , ("M-b",   runOrRaiseNext "keepassxc"               (className =? "KeePassXC"))


### PR DESCRIPTION
- Assign M-c to launch claude-desktop with matching class "Claude"
- Move chromium shortcut to M-S-c to avoid conflict and improve workflow
