### PR TITLE
fix(xmonad): update Chromium browser class matcher

### DIFF
--- a/src/XMonad/Key.hs
+++ b/src/XMonad/Key.hs
@@ -58,7 +58,7 @@ myKeys hostChassis conf@XConfig{modMask} = mkKeymap conf
   , ("M-f",   runOrRaiseNext "nautilus"                (className =? "org.gnome.Nautilus"))
   , ("M-g",   runOrRaiseNext "gimp"                    (className ~? "Gimp"))
   , ("M-c",   runOrRaiseNext "claude-desktop"          (className =? "Claude"))
-  , ("M-S-c", runOrRaiseNext "chromium"                (className =? "Chromium-browser-chromium"))
+  , ("M-S-c", runOrRaiseNext "chromium"                (className =? "Chromium-browser"))
   , ("M-r",   runOrRaiseNext "evince"                  (className =? "Evince"))
 
   , ("M-b",   runOrRaiseNext "keepassxc"               (className =? "KeePassXC"))


### PR DESCRIPTION
更新で変わったのか、
GentooとNixOSで違うのか、
わからないが、
とにかく今はこちらである。
