### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -121,11 +121,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1759537480,
-        "narHash": "sha256-PN0svvFMJvNTeW944+7x8gIsDFSVVMQkovlEURUsUm8=",
+        "lastModified": 1764980769,
+        "narHash": "sha256-GR7udqehfHtR1k3qTRmygbbxN/vbZAqroR6SLNxaOYA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "afeb3e413dd333af360d6060abe23e023affd84d",
+        "rev": "a7cf7e356d4c35d04089136bbe256ba10521ad98",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1759537470,
-        "narHash": "sha256-rJA+qPF9wt3JBEXrdjNVJFVOAcdxncY5E30tTCXFZLI=",
+        "lastModified": 1764980759,
+        "narHash": "sha256-4aBYziHvJIW6If35bW6gBTf9szrsDon/kQLo7MBR7PQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "35c7af40a606576b339a476db7789ebbb8220952",
+        "rev": "dc84ef2f749161d60947e96da212373ded0b123a",
         "type": "github"
       },
       "original": {
@@ -201,16 +201,17 @@
         "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2511": "nixpkgs-2511",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1759539111,
-        "narHash": "sha256-7LHruOEggczcvmBmTUAJfE5UUuM0zAjwt7jJwMIk5MQ=",
+        "lastModified": 1764982332,
+        "narHash": "sha256-cqK5A7L8yi2pXuUNE4lLipzzv18wsZOrJsgAJ6uXpPU=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3269049024d866d8c7c421850ebea1f0a035bf24",
+        "rev": "a62c9d889082c407557174c0647c6a950fd2fcef",
         "type": "github"
       },
       "original": {
@@ -474,11 +475,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759281824,
-        "narHash": "sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0=",
+        "lastModified": 1764836381,
+        "narHash": "sha256-8jemYbbW9EBttQKHep7Rj8kzXaxsrk/lACdXA2DN5Xk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5b5be50345d4113d04ba58c444348849f5585b4a",
+        "rev": "ff06bd3398fb1bea6c937039ece7e7c8aa396ebf",
         "type": "github"
       },
       "original": {
@@ -538,11 +539,11 @@
     },
     "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1748037224,
-        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
         "type": "github"
       },
       "original": {
@@ -554,11 +555,11 @@
     },
     "nixpkgs-2505": {
       "locked": {
-        "lastModified": 1754477006,
-        "narHash": "sha256-suIgZZHXdb4ca9nN4MIcmdjeN+ZWsTwCtYAG4HExqAo=",
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4896699973299bffae27d0d9828226983544d9e9",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
         "type": "github"
       },
       "original": {
@@ -568,13 +569,29 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1754393734,
-        "narHash": "sha256-fbnmAwTQkuXHKBlcL5Nq1sMAzd3GFqCOQgEQw6Hy0Ak=",
+        "lastModified": 1764572236,
+        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a683adc19ff5228af548c6539dbc3440509bfed3",
+        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1764587062,
+        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
         "type": "github"
       },
       "original": {
@@ -612,11 +629,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1759450314,
-        "narHash": "sha256-KnOcv3NEU3FXmVwIYeEHrJr4JOLx81CpklcurACfWc4=",
+        "lastModified": 1764979984,
+        "narHash": "sha256-wFbJQgFPD3t9YqrUGWHENwokLL2wwiw5G6BCuGuRFxI=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "f8ea3e13773ce6fd88f5b6bb251c8f482a89d317",
+        "rev": "4cbb79a34cb17bc22a564ca5a6625106ee0c4bdb",
         "type": "github"
       },
       "original": {
@@ -647,11 +664,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758728421,
-        "narHash": "sha256-ySNJ008muQAds2JemiyrWYbwbG+V7S5wg3ZVKGHSFu8=",
+        "lastModified": 1762938485,
+        "narHash": "sha256-AlEObg0syDl+Spi4LsZIBrjw+snSVU4T8MOeuZJUJjM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "5eda4ee8121f97b218f7cc73f5172098d458f1d1",
+        "rev": "5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/3269049024d866d8c7c421850ebea1f0a035bf24?narHash=sha256-7LHruOEggczcvmBmTUAJfE5UUuM0zAjwt7jJwMIk5MQ%3D' (2025-10-04)
  → 'github:input-output-hk/haskell.nix/a62c9d889082c407557174c0647c6a950fd2fcef?narHash=sha256-cqK5A7L8yi2pXuUNE4lLipzzv18wsZOrJsgAJ6uXpPU%3D' (2025-12-06)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/afeb3e413dd333af360d6060abe23e023affd84d?narHash=sha256-PN0svvFMJvNTeW944%2B7x8gIsDFSVVMQkovlEURUsUm8%3D' (2025-10-04)
  → 'github:input-output-hk/hackage.nix/a7cf7e356d4c35d04089136bbe256ba10521ad98?narHash=sha256-GR7udqehfHtR1k3qTRmygbbxN/vbZAqroR6SLNxaOYA%3D' (2025-12-06)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/35c7af40a606576b339a476db7789ebbb8220952?narHash=sha256-rJA%2BqPF9wt3JBEXrdjNVJFVOAcdxncY5E30tTCXFZLI%3D' (2025-10-04)
  → 'github:input-output-hk/hackage.nix/dc84ef2f749161d60947e96da212373ded0b123a?narHash=sha256-4aBYziHvJIW6If35bW6gBTf9szrsDon/kQLo7MBR7PQ%3D' (2025-12-06)
• Updated input 'haskellNix/nixpkgs-2411':
    'github:NixOS/nixpkgs/f09dede81861f3a83f7f06641ead34f02f37597f?narHash=sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk%3D' (2025-05-23)
  → 'github:NixOS/nixpkgs/5ab036a8d97cb9476fbe81b09076e6e91d15e1b6?narHash=sha256-kNf%2BobkpJZWar7HZymXZbW%2BRlk3HTEIMlpc6FCNz0Ds%3D' (2025-06-30)
• Updated input 'haskellNix/nixpkgs-2505':
    'github:NixOS/nixpkgs/4896699973299bffae27d0d9828226983544d9e9?narHash=sha256-suIgZZHXdb4ca9nN4MIcmdjeN%2BZWsTwCtYAG4HExqAo%3D' (2025-08-06)
  → 'github:NixOS/nixpkgs/6c8f0cca84510cc79e09ea99a299c9bc17d03cb6?narHash=sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo%3D' (2025-12-01)
• Added input 'haskellNix/nixpkgs-2511':
    'github:NixOS/nixpkgs/b0924ea1889b366de6bb0018a9db70b2c43a15f8?narHash=sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz%2BfEGlE%3D' (2025-12-01)
• Updated input 'haskellNix/nixpkgs-unstable':
    'github:NixOS/nixpkgs/a683adc19ff5228af548c6539dbc3440509bfed3?narHash=sha256-fbnmAwTQkuXHKBlcL5Nq1sMAzd3GFqCOQgEQw6Hy0Ak%3D' (2025-08-05)
  → 'github:NixOS/nixpkgs/c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce?narHash=sha256-hdFa0TAVQAQLDF31cEW3enWmBP%2Bb592OvHs6WVe3D8k%3D' (2025-12-01)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/f8ea3e13773ce6fd88f5b6bb251c8f482a89d317?narHash=sha256-KnOcv3NEU3FXmVwIYeEHrJr4JOLx81CpklcurACfWc4%3D' (2025-10-03)
  → 'github:input-output-hk/stackage.nix/4cbb79a34cb17bc22a564ca5a6625106ee0c4bdb?narHash=sha256-wFbJQgFPD3t9YqrUGWHENwokLL2wwiw5G6BCuGuRFxI%3D' (2025-12-06)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/5b5be50345d4113d04ba58c444348849f5585b4a?narHash=sha256-FIBE1qXv9TKvSNwst6FumyHwCRH3BlWDpfsnqRDCll0%3D' (2025-10-01)
  → 'github:NixOS/nixpkgs/ff06bd3398fb1bea6c937039ece7e7c8aa396ebf?narHash=sha256-8jemYbbW9EBttQKHep7Rj8kzXaxsrk/lACdXA2DN5Xk%3D' (2025-12-04)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/5eda4ee8121f97b218f7cc73f5172098d458f1d1?narHash=sha256-ySNJ008muQAds2JemiyrWYbwbG%2BV7S5wg3ZVKGHSFu8%3D' (2025-09-24)
  → 'github:numtide/treefmt-nix/5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4?narHash=sha256-AlEObg0syDl%2BSpi4LsZIBrjw%2BsnSVU4T8MOeuZJUJjM%3D' (2025-11-12)
