### PR TITLE
build(nix): GHCのバージョンを9.10.2から9.10.3に更新

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
     flake-utils.lib.eachSystem [ "x86_64-linux" ] (
       system:
       let
-        ghc-version = "ghc9102";
+        ghc-version = "ghc9103"; # GHC 9.10.3
         overlays = [
           haskellNix.overlay
           (


### PR DESCRIPTION
`cabal.project`の方は更新済みでしたが、
こちらを忘れていました。
