### PR TITLE
feat(startup): snixembedを追加しSNI対応アプリをtrayerで表示可能にする

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -144,6 +144,7 @@
             birdtray
             copyq
             networkmanagerapplet
+            snixembed
             trayer
             xmobar-launch
             xmonad-helper-bin

--- a/src/XMonad/Startup.hs
+++ b/src/XMonad/Startup.hs
@@ -16,6 +16,9 @@ myStartupHook = do
     HostChassisLaptop -> myStartupHookLaptop
     _ -> return ()
   barHeight <- liftIO getBarHeight
+  -- SNI(StatusNotifierItem)をXEmbedに変換してtrayerで表示できるようにする。
+  -- trayscaleなどのSNIアプリケーション向け。
+  spawn "snixembed --fork"
   spawn $
     unwords
       [ "trayer"


### PR DESCRIPTION
- flake.nixにsnixembedを追加し依存パッケージとして管理
- XMonadのスタートアップフックでsnixembedを起動しSNIをXEmbedへ変換
- trayerでSNI対応アプリケーションのアイコン表示を実現
