### PR TITLE
build(deps): bump `flake.lock`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -121,11 +121,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1766881865,
-        "narHash": "sha256-BO+lHqIa+J6O1Fo4pSMmjVlFelH3BSX0OT3dchX7g6U=",
+        "lastModified": 1769474569,
+        "narHash": "sha256-YcKzXAZNo4MEn0guVmJ/Mf1wN+uz/jq6JGJ2lwwCfXA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c7596b296f4e4a96f20b56eb9bb4fbb06048f034",
+        "rev": "e94aa6b720158c8dee9a5a7d13a6ab908d2b3f4e",
         "type": "github"
       },
       "original": {
@@ -137,11 +137,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1766881854,
-        "narHash": "sha256-smpv0RiaaAckra3B/GD/y+hNLGBVcbIFc2edmxFJVQA=",
+        "lastModified": 1769473802,
+        "narHash": "sha256-iIISVHpN9E8sj5e4j2nUNmxksvb582uK6mOvWUFzhIg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "fa764e1164000047014f4f016a4cbc416e46c17e",
+        "rev": "edcf95090bb8450a9a1cdf3c83802f507d1ba7a1",
         "type": "github"
       },
       "original": {
@@ -183,6 +183,7 @@
         "hls-2.0": "hls-2.0",
         "hls-2.10": "hls-2.10",
         "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -207,11 +208,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1766883156,
-        "narHash": "sha256-EJM39BZ0YEEaXcOhICJeSxC18CZPNtHACdrq0QyD+xE=",
+        "lastModified": 1769475111,
+        "narHash": "sha256-r7gzNgkOtHH6ffksSxDvFkqQ37dy4hKc+sgqaFSBTT0=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "d3437c58e54ffd274135de46a03e990848540aa7",
+        "rev": "49735dc23de35b016957b220f61ea45b2d17fb93",
         "type": "github"
       },
       "original": {
@@ -300,6 +301,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -475,11 +493,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766736597,
-        "narHash": "sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ=",
+        "lastModified": 1769318308,
+        "narHash": "sha256-Mjx6p96Pkefks3+aA+72lu1xVehb6mv2yTUUqmSet6Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f560ccec6b1116b22e6ed15f4c510997d99d5852",
+        "rev": "1cd347bf3355fce6c64ab37d3967b4a2cb4b878c",
         "type": "github"
       },
       "original": {
@@ -629,11 +647,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1766794441,
-        "narHash": "sha256-F9dVFJ7ZU8DwbX2+xj+lT8hWXkABh71rOnuQTJMlcjE=",
+        "lastModified": 1769472927,
+        "narHash": "sha256-n2Jv7dUZOrBpMRMHrUoX4eOXNIkr0kglh7opMWKU+OQ=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "1f36f699286d8d86329e6479f675e3779f72df66",
+        "rev": "cea1fb3718c41ad56ed9edcc723a93f2fc8100f5",
         "type": "github"
       },
       "original": {
@@ -664,11 +682,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766000401,
-        "narHash": "sha256-+cqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI=",
+        "lastModified": 1769353635,
+        "narHash": "sha256-J0G1ACrUK29M0THPAsz429eZX07GmR9Bs/b0pB3N0dQ=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "42d96e75aa56a3f70cab7e7dc4a32868db28e8fd",
+        "rev": "f46bb205f239b415309f58166f8df6919fa88377",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'haskellNix':
    'github:input-output-hk/haskell.nix/d3437c58e54ffd274135de46a03e990848540aa7?narHash=sha256-EJM39BZ0YEEaXcOhICJeSxC18CZPNtHACdrq0QyD%2BxE%3D' (2025-12-28)
  → 'github:input-output-hk/haskell.nix/49735dc23de35b016957b220f61ea45b2d17fb93?narHash=sha256-r7gzNgkOtHH6ffksSxDvFkqQ37dy4hKc%2BsgqaFSBTT0%3D' (2026-01-27)
• Updated input 'haskellNix/hackage':
    'github:input-output-hk/hackage.nix/c7596b296f4e4a96f20b56eb9bb4fbb06048f034?narHash=sha256-BO%2BlHqIa%2BJ6O1Fo4pSMmjVlFelH3BSX0OT3dchX7g6U%3D' (2025-12-28)
  → 'github:input-output-hk/hackage.nix/e94aa6b720158c8dee9a5a7d13a6ab908d2b3f4e?narHash=sha256-YcKzXAZNo4MEn0guVmJ/Mf1wN%2Buz/jq6JGJ2lwwCfXA%3D' (2026-01-27)
• Updated input 'haskellNix/hackage-for-stackage':
    'github:input-output-hk/hackage.nix/fa764e1164000047014f4f016a4cbc416e46c17e?narHash=sha256-smpv0RiaaAckra3B/GD/y%2BhNLGBVcbIFc2edmxFJVQA%3D' (2025-12-28)
  → 'github:input-output-hk/hackage.nix/edcf95090bb8450a9a1cdf3c83802f507d1ba7a1?narHash=sha256-iIISVHpN9E8sj5e4j2nUNmxksvb582uK6mOvWUFzhIg%3D' (2026-01-27)
• Added input 'haskellNix/hls-2.12':
    'github:haskell/haskell-language-server/7d983de4fa7ff54369f6dd31444bdb9869aec83e?narHash=sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w%3D' (2025-09-24)
• Updated input 'haskellNix/stackage':
    'github:input-output-hk/stackage.nix/1f36f699286d8d86329e6479f675e3779f72df66?narHash=sha256-F9dVFJ7ZU8DwbX2%2Bxj%2BlT8hWXkABh71rOnuQTJMlcjE%3D' (2025-12-27)
  → 'github:input-output-hk/stackage.nix/cea1fb3718c41ad56ed9edcc723a93f2fc8100f5?narHash=sha256-n2Jv7dUZOrBpMRMHrUoX4eOXNIkr0kglh7opMWKU%2BOQ%3D' (2026-01-27)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/f560ccec6b1116b22e6ed15f4c510997d99d5852?narHash=sha256-BASnpCLodmgiVn0M1MU2Pqyoz0aHwar/0qLkp7CjvSQ%3D' (2025-12-26)
  → 'github:NixOS/nixpkgs/1cd347bf3355fce6c64ab37d3967b4a2cb4b878c?narHash=sha256-Mjx6p96Pkefks3%2BaA%2B72lu1xVehb6mv2yTUUqmSet6Q%3D' (2026-01-25)
• Updated input 'treefmt-nix':
    'github:numtide/treefmt-nix/42d96e75aa56a3f70cab7e7dc4a32868db28e8fd?narHash=sha256-%2BcqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI%3D' (2025-12-17)
  → 'github:numtide/treefmt-nix/f46bb205f239b415309f58166f8df6919fa88377?narHash=sha256-J0G1ACrUK29M0THPAsz429eZX07GmR9Bs/b0pB3N0dQ%3D' (2026-01-25)
