### PR TITLE
fix: flake.nixにimagemagickとoxipngをruntime依存として追加

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -192,7 +192,9 @@
           paths = with pkgs; [
             birdtray
             copyq
+            imagemagick
             networkmanagerapplet
+            oxipng
             snixembed
             trayer
             xmobar-launch


### PR DESCRIPTION
本当はcabalファイルに追加したほうが良いのかもしれません。
