### PR TITLE
fix(key): emacsclient-with-fallbackスクリプトを追加しキーバインドを修正

### DIFF
--- a/bin/emacsclient-with-fallback
+++ b/bin/emacsclient-with-fallback
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec emacsclient --create-frame --no-wait -a emacs

--- a/src/XMonad/Key.hs
+++ b/src/XMonad/Key.hs
@@ -51,7 +51,7 @@ myKeys hostChassis conf@XConfig{modMask} =
     , ("M-S-d", runOrRaiseNext "jd.sh" (className =? "Jdim"))
     , ("M-h", runOrRaiseNext "firefox" (className ~? "firefox"))
     , ("M-t", runOrRaiseNext "kitty" (className =? "kitty"))
-    , ("M-n", runOrRaiseNext "emacsclient --create-frame --no-wait -a emacs" (className =? "Emacs"))
+    , ("M-n", runOrRaiseNext "emacsclient-with-fallback" (className =? "Emacs"))
     , ("M-s", runOrRaiseNext "slack" (className =? "Slack"))
     , ("M-f", runOrRaiseNext "nautilus" (className =? "org.gnome.Nautilus"))
     , ("M-g", runOrRaiseNext "gimp" (className ~? "Gimp"))


### PR DESCRIPTION
シェルは受け付けられなかったので単一コマンドにする必要がありました。。

- emacsclient起動用のbin/emacsclient-with-fallbackスクリプトを新規追加
- XMonadのM-nキーバインドで新スクリプトを利用するよう変更
