### PR TITLE
refactor(nix): haskell.nixからflake-parts構成へ移行

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,503 +1,49 @@
 {
   "nodes": {
-    "HTTP": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1451647621,
-        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
-        "owner": "phadej",
-        "repo": "HTTP",
-        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
-        "type": "github"
-      },
-      "original": {
-        "owner": "phadej",
-        "repo": "HTTP",
-        "type": "github"
-      }
-    },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-34": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645834128,
-        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.4",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-36": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1669081697,
-        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cardano-shell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1608537748,
-        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1672831974,
-        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "hkm/gitlab-fix",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "hackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1769474569,
-        "narHash": "sha256-YcKzXAZNo4MEn0guVmJ/Mf1wN+uz/jq6JGJ2lwwCfXA=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "e94aa6b720158c8dee9a5a7d13a6ab908d2b3f4e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
-    "hackage-for-stackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1769473802,
-        "narHash": "sha256-iIISVHpN9E8sj5e4j2nUNmxksvb582uK6mOvWUFzhIg=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "edcf95090bb8450a9a1cdf3c83802f507d1ba7a1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "for-stackage",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
-    "hackage-internal": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1750307553,
-        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
-    "haskellNix": {
-      "inputs": {
-        "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
-        "cabal-34": "cabal-34",
-        "cabal-36": "cabal-36",
-        "cardano-shell": "cardano-shell",
-        "flake-compat": "flake-compat",
-        "hackage": "hackage",
-        "hackage-for-stackage": "hackage-for-stackage",
-        "hackage-internal": "hackage-internal",
-        "hls": "hls",
-        "hls-1.10": "hls-1.10",
-        "hls-2.0": "hls-2.0",
-        "hls-2.10": "hls-2.10",
-        "hls-2.11": "hls-2.11",
-        "hls-2.12": "hls-2.12",
-        "hls-2.2": "hls-2.2",
-        "hls-2.3": "hls-2.3",
-        "hls-2.4": "hls-2.4",
-        "hls-2.5": "hls-2.5",
-        "hls-2.6": "hls-2.6",
-        "hls-2.7": "hls-2.7",
-        "hls-2.8": "hls-2.8",
-        "hls-2.9": "hls-2.9",
-        "hpc-coveralls": "hpc-coveralls",
-        "iserv-proxy": "iserv-proxy",
-        "nixpkgs": [
+        "nixpkgs-lib": [
           "nixpkgs"
-        ],
-        "nixpkgs-2305": "nixpkgs-2305",
-        "nixpkgs-2311": "nixpkgs-2311",
-        "nixpkgs-2405": "nixpkgs-2405",
-        "nixpkgs-2411": "nixpkgs-2411",
-        "nixpkgs-2505": "nixpkgs-2505",
-        "nixpkgs-2511": "nixpkgs-2511",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "old-ghc-nix": "old-ghc-nix",
-        "stackage": "stackage"
+        ]
       },
       "locked": {
-        "lastModified": 1769475111,
-        "narHash": "sha256-r7gzNgkOtHH6ffksSxDvFkqQ37dy4hKc+sgqaFSBTT0=",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "49735dc23de35b016957b220f61ea45b2d17fb93",
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
-    "hls": {
+    "gtk2hs": {
       "flake": false,
       "locked": {
-        "lastModified": 1741604408,
-        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "lastModified": 1747484193,
+        "narHash": "sha256-1rionULNPK/tE3LjDo9xHuhkFCeZ7xmYrvd1Mwd8FbQ=",
+        "owner": "ncaq",
+        "repo": "gtk2hs",
+        "rev": "260805611e54e60383c1d98c5c0a29ad9c2efe7f",
         "type": "github"
       },
       "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
+        "owner": "ncaq",
+        "repo": "gtk2hs",
+        "rev": "260805611e54e60383c1d98c5c0a29ad9c2efe7f",
         "type": "github"
       }
     },
-    "hls-1.10": {
-      "flake": false,
+    "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1680000865,
-        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "1.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.0": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1687698105,
-        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "783905f211ac63edf982dd1889c671653327e441",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.0.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1743069404,
-        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.11": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1747306193,
-        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.11.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.12": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1758709460,
-        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.12.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1693064058,
-        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.2.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1695910642,
-        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.3.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1699862708,
-        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.4.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1701080174,
-        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.5.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.6": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1705325287,
-        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.6.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.7": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1708965829,
-        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.7.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.8": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1715153580,
-        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.8.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.9": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1719993701,
-        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.9.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hpc-coveralls": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1607498076,
-        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "type": "github"
-      }
-    },
-    "iserv-proxy": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1755243078,
-        "narHash": "sha256-GLbl1YaohKdpzZVJFRdcI1O1oE3F3uBer4lFv3Yy0l8=",
-        "owner": "stable-haskell",
-        "repo": "iserv-proxy",
-        "rev": "150605195cb7183a6fb7bed82f23fedf37c6f52a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "stable-haskell",
-        "ref": "iserv-syms",
-        "repo": "iserv-proxy",
-        "type": "github"
-      }
-    },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1769318308,
-        "narHash": "sha256-Mjx6p96Pkefks3+aA+72lu1xVehb6mv2yTUUqmSet6Q=",
+        "lastModified": 1770617025,
+        "narHash": "sha256-1jZvgZoAagZZB6NwGRv2T2ezPy+X6EFDsJm+YSlsvEs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1cd347bf3355fce6c64ab37d3967b4a2cb4b878c",
+        "rev": "2db38e08fdadcc0ce3232f7279bab59a15b94482",
         "type": "github"
       },
       "original": {
@@ -507,172 +53,15 @@
         "type": "github"
       }
     },
-    "nixpkgs-2305": {
-      "locked": {
-        "lastModified": 1705033721,
-        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2311": {
-      "locked": {
-        "lastModified": 1719957072,
-        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2405": {
-      "locked": {
-        "lastModified": 1735564410,
-        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-24.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2411": {
-      "locked": {
-        "lastModified": 1751290243,
-        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-24.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2505": {
-      "locked": {
-        "lastModified": 1764560356,
-        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-25.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2511": {
-      "locked": {
-        "lastModified": 1764572236,
-        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-25.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1764587062,
-        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "old-ghc-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1631092763,
-        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
-        "owner": "angerman",
-        "repo": "old-ghc-nix",
-        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "angerman",
-        "ref": "master",
-        "repo": "old-ghc-nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "haskellNix": "haskellNix",
-        "nixpkgs": "nixpkgs",
+        "flake-parts": "flake-parts",
+        "gtk2hs": "gtk2hs",
+        "nixpkgs": [
+          "nixpkgs-2511"
+        ],
+        "nixpkgs-2511": "nixpkgs-2511",
         "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "stackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1769472927,
-        "narHash": "sha256-n2Jv7dUZOrBpMRMHrUoX4eOXNIkr0kglh7opMWKU+OQ=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "cea1fb3718c41ad56ed9edcc723a93f2fc8100f5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     },
     "treefmt-nix": {
@@ -682,11 +71,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769353635,
-        "narHash": "sha256-J0G1ACrUK29M0THPAsz429eZX07GmR9Bs/b0pB3N0dQ=",
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "f46bb205f239b415309f58166f8df6919fa88377",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,245 +1,205 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.follows = "nixpkgs-2511";
+    nixpkgs-2511.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    haskellNix = {
-      url = "github:input-output-hk/haskell.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
+    gtk2hs = {
+      url = "github:ncaq/gtk2hs/260805611e54e60383c1d98c5c0a29ad9c2efe7f";
+      flake = false;
     };
   };
 
   outputs =
-    {
-      self,
-      nixpkgs,
-      flake-utils,
-      treefmt-nix,
-      haskellNix,
-      ...
-    }:
-    flake-utils.lib.eachSystem [ "aarch64-linux" "x86_64-linux" ] (
-      system:
-      let
-        ghc-version = "ghc9103"; # GHC 9.10.3
-        overlays = [
-          haskellNix.overlay
-          (
-            final: _prev:
-            let
-              # haskell.nixのtoolsで参照されるhaskell-language-server。
-              tool-haskell-language-server =
-                final.haskell-nix.tool ghc-version "haskell-language-server"
-                  "latest";
-            in
-            {
-              # nixpkgsで普通にインストールされるfourmoluはhaskell-language-serverのものと違うので上書きして合わせる。
-              inherit (tool-haskell-language-server.project.hsPkgs.fourmolu.components.exes) fourmolu;
-            }
-          )
-          (final: prev: {
-            project = final.haskell-nix.project' {
-              src = ./.;
-              name = "xmonad-launch";
-              compiler-nix-name = ghc-version;
-              # IFD時にcabalやnix-toolsを実行するシステムを固定。
-              # これによりx86_64-linux上でaarch64-linux用のパッケージも評価可能になる。
-              evalSystem = "x86_64-linux";
-              modules = [
-                # `nix flake check`レベルではcabalの警告をエラーとして扱います。
-                # ライブラリの問題ない範囲の不一致とか考えるとcabalの警告はエラーにしないべきですが、
-                # CIでは通したくないので警告も含めてエラーにします。
-                # CI専用に環境を分離するのも手ですが、
-                # 元々`nix flake check`では最適化を無効にするのが面倒なので時間がかかるため、
-                # あまり反復的に実行しません。
-                # 反復的に実行してテストの結果とかを確認するのには普通は`cabal test`のような言語固有のコマンドを使います。
-                # `cabal test`の方が実行するテストをフィルタリングとかも簡単に出来ますし。
-                # そのことを考えると本番を考えてエラーにしても構わないでしょう。
-                # flake参照された時にnixpkgsをfollowすると問題ない警告をエラーにしてしまうかもしれないのが懸念点ですが、
-                # 少なくとも現在は考慮する必要はないでしょう。
-                # 注意点として、srcやtestはビルドされますが、executableであるappはビルドされません。
-                # 「appはエントリーポイントとしてのみ使う」習慣を守っていれば問題にはならないです。
-                (
-                  { lib, config, ... }:
-                  {
-                    # パッケージたちをハードコーディングすると変更忘れが発生するので`config.package-keys`で取得。
-                    options.packages = lib.genAttrs config.package-keys (
-                      _name:
-                      lib.mkOption {
-                        type = lib.types.submodule (
-                          { config, lib, ... }:
-                          # `cabal.project`に`source-repository-package`などで書かれていたりする、
-                          # 外部パッケージは変更したくないので、
-                          # `isProject`でフィルタリングしています。
-                          lib.mkIf config.package.isProject {
-                            # この書き方で上書きではなく追加として扱われる。
-                            ghcOptions = [ "-Werror" ];
-                          }
-                        );
-                      }
-                    );
-                  }
-                )
-              ];
-              shell = {
-                tools = {
-                  cabal = "latest";
-                  cabal-gild = "latest"; # treefmtで管理されているがvscodeのHaskell拡張向けに使えるようにしておく
-                  haskell-language-server = "latest";
-                  hlint = "latest";
-                  implicit-hie = "latest";
-                };
-                buildInputs = with prev; [
-                  fourmolu
-                  nil
-                  nixfmt-rfc-style
-                  parallel
-                  prev.gtk3
-                  yamllint
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
 
-                  (writeScriptBin "haskell-language-server-wrapper" ''
-                    #!${stdenv.shell}
-                    exec haskell-language-server "$@"
-                  '')
+      imports = [ inputs.treefmt-nix.flakeModule ];
+
+      perSystem =
+        {
+          pkgs,
+          config,
+          lib,
+          ...
+        }:
+        let
+          haskellPackages = pkgs.haskell.packages.ghc9103.override {
+            overrides = hself: hsuper: {
+              # gtk2hs packages from inputs.gtk2hs
+              # callCabal2nixの第3引数でpkg-config依存のHaskellパッケージ名との衝突を解決する。
+              # cabal2nixはpkgconfig-dependsもHaskellパッケージセットから探すため、
+              # glib, cairo等のシステムライブラリ名がHaskellパッケージ名と衝突して無限再帰になる。
+              gtk2hs-buildtools = hself.callCabal2nix "gtk2hs-buildtools" (inputs.gtk2hs + "/tools") { };
+              # cabal2nixはpkgconfig-dependsの名前をそのまま関数引数にするため、
+              # システムライブラリ名がHaskellパッケージ名と衝突する。
+              # 第3引数で明示的にシステムパッケージを渡して衝突を解決する。
+              glib = hself.callCabal2nix "glib" (inputs.gtk2hs + "/glib") {
+                inherit (pkgs) glib;
+              };
+              cairo = hself.callCabal2nix "cairo" (inputs.gtk2hs + "/cairo") {
+                inherit (pkgs) cairo;
+              };
+              gio = hself.callCabal2nix "gio" (inputs.gtk2hs + "/gio") {
+                system-glib = pkgs.glib;
+              };
+              pango = hself.callCabal2nix "pango" (inputs.gtk2hs + "/pango") {
+                inherit (pkgs) pango;
+              };
+              # cabal2nixはgtk3パッケージとして生成する(gtk/ディレクトリだがcabal名がgtk3)
+              gtk3 = hself.callCabal2nix "gtk3" (inputs.gtk2hs + "/gtk") {
+                inherit (pkgs) gtk3;
+              };
+
+              # xmobar with flags
+              xmobar = pkgs.haskell.lib.compose.enableCabalFlag "with_datezone" (
+                pkgs.haskell.lib.compose.enableCabalFlag "with_threaded" hsuper.xmobar
+              );
+
+              xmonad-launch = hself.callCabal2nix "xmonad-launch" inputs.self { };
+            };
+          };
+
+          xmonad-helper-bin = pkgs.runCommand "xmonad-helper-bin" { } ''
+            mkdir -p $out/bin
+            cp ${./bin}/* $out/bin/
+            chmod +x $out/bin/*
+          '';
+
+          xmonad-launch-full = pkgs.symlinkJoin {
+            name = "xmonad-launch-full";
+            paths = with pkgs; [
+              birdtray
+              copyq
+              haskellPackages.xmonad-launch
+              imagemagick
+              networkmanagerapplet
+              oxipng
+              snixembed
+              trayer
+              xmonad-helper-bin
+              xorg.xinput
+            ];
+          };
+        in
+        {
+          packages = {
+            default = xmonad-launch-full;
+          };
+
+          checks = {
+            xmonad-launch = pkgs.haskell.lib.compose.appendConfigureFlags [
+              "--ghc-options=-Werror"
+            ] haskellPackages.xmonad-launch;
+            formatting = config.treefmt.build.check inputs.self;
+          };
+
+          treefmt = {
+            # yamlfmtはprettierと競合します。
+            projectRootFile = "flake.nix";
+            programs = {
+              actionlint.enable = true;
+              deadnix.enable = true;
+              fourmolu.enable = true;
+              hlint.enable = true;
+              nixfmt.enable = true;
+              prettier.enable = true;
+              shellcheck.enable = true;
+              shfmt.enable = true;
+              statix.enable = true;
+            };
+            settings.formatter = {
+              # cabal-gildのモジュール自動発見機能に対応するため、
+              # Haskellソースファイルの変更も検知してcabal-gildを実行します。
+              # treefmt-nixの上流では変更されたファイルだけを修正したいと言われてマージされていませんが、
+              # ローカルで使う分には問題ありません。
+              # [fix(cabal): cabal-fmt and cabal-gild discover module by ncaq · Pull Request #384 · numtide/treefmt-nix](https://github.com/numtide/treefmt-nix/pull/384)
+              cabal-gild = {
+                command = lib.getExe (
+                  pkgs.writeShellApplication {
+                    name = "cabal-gild-wrapper";
+                    runtimeInputs = with pkgs; [
+                      git
+                      haskellPackages.cabal-gild
+                      parallel
+                    ];
+                    text = ''
+                      git ls-files -z "*.cabal" | parallel --null "cabal-gild --io {}"
+                    '';
+                  }
+                );
+                includes = [
+                  "*.cabal"
+                  # Haskellソースファイルの変更を検知するために含める
+                  "*.hs"
+                  "*.lhs"
+                  "*.hsc"
+                  "*.chs"
+                  "*.hsig"
+                  "*.lhsig"
+                ];
+              };
+              editorconfig-checker = {
+                command = lib.getExe (
+                  pkgs.writeShellApplication {
+                    name = "editorconfig-checker-wrapper";
+                    runtimeInputs = [ pkgs.editorconfig-checker ];
+                    text = ''
+                      editorconfig-checker -config .editorconfig-checker.json "$@"
+                    '';
+                  }
+                );
+                includes = [ "*" ];
+                excludes = [
+                  ".direnv/*"
+                  ".git/*"
+                  "dist-newstyle/*"
+                  "result*"
                 ];
               };
             };
-          })
-        ];
-        pkgs = import nixpkgs {
-          inherit system overlays;
-          inherit (haskellNix) config;
-        };
-        flake = pkgs.project.flake { };
-        treefmtEval = treefmt-nix.lib.evalModule pkgs (_: {
-          # yamlfmtはprettierと競合します。
-          projectRootFile = "flake.nix";
-          programs = {
-            actionlint.enable = true;
-            deadnix.enable = true;
-            hlint.enable = true;
-            nixfmt.enable = true;
-            prettier.enable = true;
-            shellcheck.enable = true;
-            shfmt.enable = true;
-            statix.enable = true;
+          };
 
-            fourmolu = {
-              enable = true;
-              package = pkgs.fourmolu;
-            };
+          devShells.default = haskellPackages.shellFor {
+            packages = p: [ p.xmonad-launch ];
+            nativeBuildInputs = with pkgs; [
+              cabal-install
+              fourmolu
+              gtk3
+              haskell-language-server
+              haskellPackages.cabal-gild
+              hlint
+              nil
+              nixfmt
+              yamllint
+
+              (pkgs.writeScriptBin "haskell-language-server-wrapper" ''
+                #!${pkgs.stdenv.shell}
+                exec haskell-language-server "$@"
+              '')
+            ];
           };
-          settings.formatter = {
-            # cabal-gildのモジュール自動発見機能に対応するため、
-            # Haskellソースファイルの変更も検知してcabal-gildを実行します。
-            # treefmt-nixの上流では変更されたファイルだけを修正したいと言われてマージされていませんが、
-            # ローカルで使う分には問題ありません。
-            # [fix(cabal): cabal-fmt and cabal-gild discover module by ncaq · Pull Request #384 · numtide/treefmt-nix](https://github.com/numtide/treefmt-nix/pull/384)
-            cabal-gild = {
-              command = pkgs.lib.getExe (
-                pkgs.writeShellApplication {
-                  name = "cabal-gild-wrapper";
-                  runtimeInputs = [
-                    (pkgs.haskell-nix.tool ghc-version "cabal-gild" "1.6.0.2")
-                    pkgs.git
-                    pkgs.parallel
-                  ];
-                  text = ''
-                    git ls-files -z "*.cabal" | parallel --null "cabal-gild --io {}"
-                  '';
-                }
-              );
-              includes = [
-                "*.cabal"
-                # Haskellソースファイルの変更を検知するために含める
-                "*.hs"
-                "*.lhs"
-                "*.hsc"
-                "*.chs"
-                "*.hsig"
-                "*.lhsig"
-              ];
-            };
-            editorconfig-checker = {
-              command = pkgs.lib.getExe (
-                pkgs.writeShellApplication {
-                  name = "editorconfig-checker-wrapper";
-                  runtimeInputs = [ pkgs.editorconfig-checker ];
-                  text = ''
-                    editorconfig-checker -config .editorconfig-checker.json "$@"
-                  '';
-                }
-              );
-              includes = [ "*" ];
-              excludes = [
-                ".direnv/*"
-                ".git/*"
-                "dist-newstyle/*"
-                "result*"
-              ];
-            };
-          };
-        });
-        xmonad-launch = flake.packages."xmonad-launch:exe:xmonad-launch";
-        xmobar-launch = flake.packages."xmonad-launch:exe:xmobar-launch";
-        xmonad-helper-bin = pkgs.runCommand "xmonad-helper-bin" { } ''
-          mkdir -p $out/bin
-          cp ${./bin}/* $out/bin/
-          chmod +x $out/bin/*
-        '';
-        xmonad-launch-full = pkgs.symlinkJoin {
-          name = "xmonad-launch-full";
-          paths = with pkgs; [
-            birdtray
-            copyq
-            imagemagick
-            networkmanagerapplet
-            oxipng
-            snixembed
-            trayer
-            xmobar-launch
-            xmonad-helper-bin
-            xmonad-launch
-            xorg.xinput
-          ];
         };
-      in
-      # haskell.nixのproject.flakeはciJobsとhydraJobsを生成するが、
-      # ciJobsは非標準のoutputであり警告を誘発し、
-      # hydraJobsもGitHub Actionsを使うため不要なので除外。
-      builtins.removeAttrs flake [
-        "ciJobs"
-        "hydraJobs"
-      ]
-      // {
-        checks =
-          flake.packages # テストがないパッケージもビルドしてエラーを検出する。
-          // flake.checks
-          // {
-            formatting = treefmtEval.config.build.check self;
-          };
-        formatter = treefmtEval.config.build.wrapper;
-        packages = flake.packages // {
-          default = xmonad-launch-full;
-          xmobar-launch = flake.packages."xmonad-launch:exe:xmobar-launch";
-          xmonad-launch = flake.packages."xmonad-launch:exe:xmonad-launch";
-        };
-      }
-    );
+    };
 
   nixConfig = {
     extra-substituters = [
       "https://cache.nixos.org/"
-      "https://cache.iog.io"
       "https://nix-community.cachix.org"
       "https://ncaq-xmonad.cachix.org"
     ];
     extra-trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "ncaq-xmonad.cachix.org-1:ngWi7GYMyNG5XYhjqRnPphQdViZdZcJ5b+IZ1FD3ebg="
     ];


### PR DESCRIPTION
dotfilesにhaskell.nixを参照させるとキャッシュが効いていても、
更新のためにそこそこ長いダウンロードの時間がかかります。
haskell.nixの多数の機能は有用ですが、
これは個人のウインドウマネージャの構成であり、
例えばGHCのバージョンの細かいマネジメントは不要だと思ったので、
シンプルな構成に移行しました。

- flake.nixをhaskell.nix依存からflake-partsとgtk2hs依存に書き換え
- flake.lockを対応する依存に更新
- haskell.nixのproject.flake構成を削除し、haskellPackagesを直接定義
- gtk2hsパッケージをinputsから参照し、無限再帰回避のためpkg-config依存を明示
- devShellやtreefmt設定をflake-parts方式に移行
- xmobarやxmonad-launchのビルド方法を調整
- nixConfigから不要なsubstituterとpublic-keyを削除
