### PR TITLE
build(flake): nixpkgsのチャンネルを一度分けるのをやめる

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,7 +37,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-2511": {
+    "nixpkgs": {
       "locked": {
         "lastModified": 1770617025,
         "narHash": "sha256-1jZvgZoAagZZB6NwGRv2T2ezPy+X6EFDsJm+YSlsvEs=",
@@ -57,10 +57,7 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "gtk2hs": "gtk2hs",
-        "nixpkgs": [
-          "nixpkgs-2511"
-        ],
-        "nixpkgs-2511": "nixpkgs-2511",
+        "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs = {
-    nixpkgs.follows = "nixpkgs-2511";
-    nixpkgs-2511.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";


### PR DESCRIPTION
複数のチャンネルを参照する余地の高いdotfilesならともかく、
ここでそれをやっても益は少なく、
参照した時に上書きしにくいと判断しました。
