### PR TITLE
ci: 共通キャッシュ設定

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,7 +7,6 @@ on:
   pull_request:
 
 permissions:
-  actions: write # キャッシュアクションに必要
   contents: read # リポジトリコンテンツの読み取り
 
 jobs:
@@ -17,10 +16,12 @@ jobs:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
         with:
-          extra_nix_config: |
-            accept-flake-config = true
+          # セルフホストランナーでうっかり外部からの悪意あるPRを実行許可してしまい、
+          # flake.nixの設定を受け入れると好きなキャッシュを入れられたりしてセキュリティリスクがあるため、
+          # GitHubホストランナーでのみflake.nixの設定を自動で受け入れるようにしています。
+          extra_nix_config: ${{ runner.environment == 'github-hosted' && 'accept-flake-config = true' || '' }}
       - uses: cachix/cachix-action@v16
         with:
-          name: ncaq-xmonad
+          name: ncaq
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: nix flake check

--- a/flake.nix
+++ b/flake.nix
@@ -194,13 +194,15 @@
   nixConfig = {
     extra-substituters = [
       "https://cache.nixos.org/"
-      "https://nix-community.cachix.org"
-      "https://ncaq-xmonad.cachix.org"
+      "https://niks3-public.ncaq.net/"
+      "https://ncaq.cachix.org/"
+      "https://nix-community.cachix.org/"
     ];
     extra-trusted-public-keys = [
       "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
+      "niks3-public.ncaq.net-1:e/B9GomqDchMBmx3IW/TMQDF8sjUCQzEofKhpehXl04="
+      "ncaq.cachix.org-1:XF346GXI2n77SB5Yzqwhdfo7r0nFcZBaHsiiMOEljiE="
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
-      "ncaq-xmonad.cachix.org-1:ngWi7GYMyNG5XYhjqRnPphQdViZdZcJ5b+IZ1FD3ebg="
     ];
     allow-import-from-derivation = true;
   };


### PR DESCRIPTION
cachixのキャッシュを効率のために原則ncaqに統一することにしました。
統一して利用している自分のオンプレキャッシュを追加しました。
flake.nixのものをそのまま受け入れるのはGitHubホストランナーのみです。
GitHubのキャッシュには触れないはずなので権限を除去しました。
