### PR TITLE
feat(key): ロックコマンドをdm-toolからloginctlに変更

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,7 @@
               networkmanagerapplet
               oxipng
               snixembed
+              systemd
               trayer
               xmonad-helper-bin
               xorg.xinput

--- a/src/XMonad/Key.hs
+++ b/src/XMonad/Key.hs
@@ -80,7 +80,7 @@ myKeys hostChassis conf@XConfig{modMask} =
       if hostChassis == HostChassisLaptop
         then
           [ ("<XF86Calculator>", toggleTouchPad) -- 意味的に適切ではないが、適切なキーがないため代用。
-          , ("M-l", spawn "dm-tool lock") -- M-lにロックを割り当てておかないとロックファンクションキーも動かなくなる。
+          , ("M-l", spawn "loginctl lock-session") -- M-lにロックを割り当てておかないとロックファンクションキーも動かなくなる。
           ]
         else []
 


### PR DESCRIPTION
真面目にスクリーンロックを導入する予定のため。

- XMonadのロックキー割り当てをdm-tool lockからloginctl lock-sessionに変更
- systemdを依存パッケージに追加
