### PR TITLE
refactor: ウインドウマネージャに依存しないデーモンの管理をシステム設定に移動

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,6 @@
               imagemagick
               oxipng
               snixembed
-              systemd
               trayer
               xmonad-helper-bin
               xorg.xinput

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,6 @@
               copyq
               haskellPackages.xmonad-launch
               imagemagick
-              networkmanagerapplet
               oxipng
               snixembed
               systemd

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,6 @@
           xmonad-launch-full = pkgs.symlinkJoin {
             name = "xmonad-launch-full";
             paths = with pkgs; [
-              copyq
               haskellPackages.xmonad-launch
               imagemagick
               oxipng

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,6 @@
           xmonad-launch-full = pkgs.symlinkJoin {
             name = "xmonad-launch-full";
             paths = with pkgs; [
-              birdtray
               copyq
               haskellPackages.xmonad-launch
               imagemagick

--- a/src/XMonad/Startup.hs
+++ b/src/XMonad/Startup.hs
@@ -12,7 +12,6 @@ myStartupHook = do
   -- 各デバイス向け設定。
   hostChassis <- getHostChassisXMonad
   case hostChassis of
-    HostChassisDesktop -> myStartupHookDesktop
     HostChassisLaptop -> myStartupHookLaptop
     _ -> return ()
   barHeight <- liftIO getBarHeight
@@ -34,17 +33,6 @@ myStartupHook = do
       ]
   spawn "copyq"
   spawn "nm-applet"
-
--- | デスクトップ環境での初期設定。
-myStartupHookDesktop :: X ()
-myStartupHookDesktop = do
-  -- Thunderbirdの未読メール通知アイコンを表示するプログラムなのですが、
-  -- やたらとCPUとメモリを食います。
-  -- CPUコアなんて基本的に余っているので、
-  -- デスクトップPCでは別に無害なのですが、
-  -- ラップトップPCではバッテリーを気にする必要があるので、
-  -- デスクトップPCでのみ有効にすることにします。
-  spawn "birdtray"
 
 -- | ラップトップ環境での初期設定。
 myStartupHookLaptop :: X ()

--- a/src/XMonad/Startup.hs
+++ b/src/XMonad/Startup.hs
@@ -31,7 +31,6 @@ myStartupHook = do
       , "--transparent true"
       , "--alpha 255"
       ]
-  spawn "copyq"
 
 -- | ラップトップ環境での初期設定。
 myStartupHookLaptop :: X ()

--- a/src/XMonad/Startup.hs
+++ b/src/XMonad/Startup.hs
@@ -32,7 +32,6 @@ myStartupHook = do
       , "--alpha 255"
       ]
   spawn "copyq"
-  spawn "nm-applet"
 
 -- | ラップトップ環境での初期設定。
 myStartupHookLaptop :: X ()


### PR DESCRIPTION
以前はここが自動起動プログラムの管理をせざるを得なかった面がありましたが、
NixOSを利用するようになってそうでもなくなったので、
むしろNixOS Moduleとかを使いやすくするために、
XMonadやこのコードにあまり関係しないものは移動します。

他にも色々移動できるところがあるかもしれませんが、
とりあえずはこの範囲で移動します。

close #68