### PR TITLE
fix(key): claudeの`className`を小文字表記に修正

### DIFF
--- a/src/XMonad/Key.hs
+++ b/src/XMonad/Key.hs
@@ -55,7 +55,7 @@ myKeys hostChassis conf@XConfig{modMask} =
     , ("M-s", runOrRaiseNext "slack" (className =? "Slack"))
     , ("M-f", runOrRaiseNext "nautilus" (className =? "org.gnome.Nautilus"))
     , ("M-g", runOrRaiseNext "gimp" (className ~? "Gimp"))
-    , ("M-c", runOrRaiseNext "claude-desktop" (className =? "Claude"))
+    , ("M-c", runOrRaiseNext "claude-desktop" (className =? "claude"))
     , ("M-S-c", runOrRaiseNext "chromium" (className =? "Chromium-browser"))
     , ("M-r", runOrRaiseNext "evince" (className =? "Evince"))
     , ("M-b", runOrRaiseNext "keepassxc" (className =? "KeePassXC"))


### PR DESCRIPTION
サイレントに、

```
WM_CLASS(STRING) = "claude", "claude"
```

に変更されたっぽい。
