### PR TITLE
fix: `youtube-music`の実行コマンドが`pear-desktop`に変更されたのに追随

### DIFF
--- a/src/XMonad/Key.hs
+++ b/src/XMonad/Key.hs
@@ -65,7 +65,7 @@ myKeys hostChassis conf@XConfig{modMask} =
     , ("M-w", runOrRaiseNext "eog" (className =? "Eog"))
     , ("M-v", runOrRaiseNext "copyq-show" (className =? "copyq"))
     , ("M-S-v", runOrRaiseNext "vlc" (className =? "vlc"))
-    , ("M-z", runOrRaiseNext "youtube-music" (className =? "com.github.th_ch.youtube_music"))
+    , ("M-z", runOrRaiseNext "pear-desktop" (className =? "com.github.th_ch.youtube_music"))
     , ("M-S-z", runOrRaiseNext "zoom-fix-v4l" (className =? "zoom"))
     ]
     <> Map.fromList


### PR DESCRIPTION
`className`に変動はなかった。
