### PR TITLE
build(deps): cabalのindex-stateを更新

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,6 @@
 packages: .
 with-compiler: ghc-9.10.3
-index-state: 2025-12-27T19:24:07Z
+index-state: 2026-06-13T20:52:20Z
 
 package xmonad-launch
   ghc-options: -j


### PR DESCRIPTION
`cabal.project`の`index-state`を`2026-06-13T20:52:20Z`に更新しました。
