### PR TITLE
fix: Steamのクラス名を小文字のsteamに変更

### DIFF
--- a/src/XMonad/Key.hs
+++ b/src/XMonad/Key.hs
@@ -46,7 +46,7 @@ myKeys hostChassis conf@XConfig{modMask} =
     , ("M-S-i", runOrRaiseNext "idea-community" (className ~? "jetbrains-idea"))
     , ("M-p", runOrRaiseNext "pwvucontrol" (className ~? "pwvucontrol"))
     , ("M-y", runOrRaiseNext "rhythmbox" (className =? "Rhythmbox"))
-    , ("M-x", runOrRaiseNext "steam" (className =? "Steam"))
+    , ("M-x", runOrRaiseNext "steam" (className =? "steam"))
     , ("M-d", runOrRaiseNext "discord" (className =? "discord"))
     , ("M-S-d", runOrRaiseNext "jd.sh" (className =? "Jdim"))
     , ("M-h", runOrRaiseNext "firefox" (className ~? "firefox"))


### PR DESCRIPTION
久しぶりにSteamのLinuxクライアントを起動して`xprop`で確認したところ、
小文字の`steam`にクラス名が変更されていたため。
